### PR TITLE
fix the cqfd build of nsec 2019 badge firmware

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -14,3 +14,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3-pil \
 	python3-pycparser \
 	python3-serial
+
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	wget \
+	unzip
+
+RUN ln -nsf /usr/bin/python3 /usr/local/bin/python

--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -13,10 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3 \
 	python3-pil \
 	python3-pycparser \
-	python3-serial
-
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
+	python3-serial \
 	wget \
 	unzip
 


### PR DESCRIPTION
 tested by build of `cqfd init && cqfd` on master from a clean clone