### PR TITLE
Flash lock/unlock gdb script improvements

### DIFF
--- a/nrf52/flash.gdb
+++ b/nrf52/flash.gdb
@@ -7,11 +7,21 @@ else
   set tdesc filename gdb-tdesc-cortex-m4f.xml
 end
 monitor swdp_scan
-attach 1
-set mem inaccessible-by-default off
-set debug arm
+
 if $FORCE_ERASE_ALL
+  set non-stop on
+python
+def ignore_error(cmd):
+  try:
+    gdb.execute(cmd)
+  except:
+    gdb.execute("echo ignoring error\\n")
+    pass
+ignore_error("attach 1")
+end
   monitor erase_mass
+  monitor swdp_scan
+  set non-stop off
 end
 if $LOAD_SOFTDEVICE
   load nordicsdk/softdevice/s132/hex/s132_nrf52_5.0.0_softdevice.hex

--- a/nrf52/flash.gdb
+++ b/nrf52/flash.gdb
@@ -23,11 +23,20 @@ end
   monitor swdp_scan
   set non-stop off
 end
+set mem inaccessible-by-default off
+set debug arm
+attach 1
+
 if $LOAD_SOFTDEVICE
   load nordicsdk/softdevice/s132/hex/s132_nrf52_5.0.0_softdevice.hex
 end
+
 load builds/nsec19_nrf52_ctf.out
 file builds/nsec19_nrf52_ctf.out
+
+if $LOCK_AFTER_FLASH
+  monitor enable_approtect
+end
 
 define hook-quit
   set confirm off

--- a/nrf52/flash_config.gdb.template
+++ b/nrf52/flash_config.gdb.template
@@ -2,7 +2,7 @@
 # "/dev/stty0" or "/dev/ttyUSB0" (Linux), "/dev/cu.usbmodem012345678" (macOS)
 target extended-remote /dev/ttyACM0
 
-# Erase all the data (App and SoftDevice) from the chip before flashing.
+# Unlock & Erase all the data (App and SoftDevice) from the chip before flashing.
 set $FORCE_ERASE_ALL = 0
 
 # Change to 1 if you need to load the SoftDevice into the chip. This can be once

--- a/nrf52/flash_config.gdb.template
+++ b/nrf52/flash_config.gdb.template
@@ -5,6 +5,9 @@ target extended-remote /dev/ttyACM0
 # Unlock & Erase all the data (App and SoftDevice) from the chip before flashing.
 set $FORCE_ERASE_ALL = 0
 
+# Lock after flashing is done
+set $LOCK_AFTER_FLASH = 0
+
 # Change to 1 if you need to load the SoftDevice into the chip. This can be once
 # and when SoftDevice version is updated.
 set $LOAD_SOFTDEVICE = 0


### PR DESCRIPTION
* add a `$LOCK_AFTER_FLASH` flag to flash_config.gdb.template to enable setting APPROTECT after flashing
* use python wrapper to ignore failed `attach 1` when nrf52 is locked and `$FORCE_ERASE_ALL` is set. the failed command is necessary to invoke the BMP `erase_mass` nrf52 specific command.