### PR TITLE
update 2018 so # LEDs can be easily changed

### DIFF
--- a/nrf52/nsec_led_ble.c
+++ b/nrf52/nsec_led_ble.c
@@ -63,9 +63,9 @@ ServiceCharacteristic segment_index_char, start_segment_char, stop_segment_char,
 
 bool is_ble_controled = false;
 
-// Possible to set up to 8 segment
+// Possible to set up to NEOPIXEL_COUNT segment
 uint8_t selected_segment = 0;
-SegmentBle segment_array[8];
+SegmentBle segment_array[NEOPIXEL_COUNT];
 uint8_t brightness = 60;
 bool unlock_state = false;
 

--- a/nrf52/nsec_storage.c
+++ b/nrf52/nsec_storage.c
@@ -55,7 +55,7 @@ typedef struct LedSettings_t {
     bool control;
     bool is_ble_controlled;
     bool ble_control_permitted;
-    SegmentBle segment_array[8];
+    SegmentBle segment_array[NEOPIXEL_COUNT];
 } LedSettings;
 
 LedSettings actual_settings;

--- a/nrf52/ws2812fx.c
+++ b/nrf52/ws2812fx.c
@@ -520,7 +520,7 @@ void resetSegments_WS2812FX() {
   memset(fx->segment_runtimes, 0, sizeof(fx->segment_runtimes));
   fx->segment_index = 0;
   fx->num_segments = 1;
-  setSegment_WS2812FX(0, 0, 7, FX_MODE_STATIC, DEFAULT_COLOR, DEFAULT_SPEED, false);
+  setSegment_WS2812FX(0, 0, NEOPIXEL_COUNT - 1, FX_MODE_STATIC, DEFAULT_COLOR, DEFAULT_SPEED, false);
 }
 
 /* #####################################################

--- a/nrf52/ws2812fx.h
+++ b/nrf52/ws2812fx.h
@@ -45,7 +45,7 @@
 
 /* each segment uses 36 bytes of SRAM memory, so if you're application fails because of
   insufficient memory, decreasing MAX_NUM_SEGMENTS may help */
-#define MAX_NUM_SEGMENTS 8
+#define MAX_NUM_SEGMENTS NEOPIXEL_COUNT
 #define NUM_COLORS 3     /* number of colors per segment */
 
 // some common colors


### PR DESCRIPTION
cherry-picks the only commit  from #2 which came at a bad time b/c the nsec 2019 firmware was underway:

27e1ba0d28ce007917d8c2ff0f1e76d59232b3bf make number of WS1812s parametrized on NEOPIXEL_COUNT (remove hardcoded 8s and 7s)

The reason I bring this back up: I'll be delivering a short demonstration of how to add more LEDs to these awesome badges and merging this commit here would make it easier for people to do it too :)